### PR TITLE
Release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ craftping is a Rust library to ping Minecraft Servers.
 
 ```toml
 [dependencies]
-craftping = "0.3.1"
+craftping = "0.4.0"
 ```
 
 You can synchronously ping to the server with `craftping::sync::ping`:

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -47,19 +47,19 @@ pub struct Response {
     /// See also [the minecraft protocol wiki](https://wiki.vg/Minecraft_Forge_Handshake#FML2_protocol_.281.13_-_Current.29)
     /// for the [`ForgeData`](ForgeData) format.
     pub forge_data: Option<ForgeData>,
-    /// The raw json string returned from the server.
-    /// If the server uses legacy protocol, (thus not returned json) it is simply `None`.
-    /// It is `Vec<u8>` because server is not guaranteed to return valid UTF-8.
+    /// The raw response returned from the server.
+    /// It is `Vec<u8>` because server is not guaranteed to return valid UTF-8,
+    /// even not a json at all.
     #[serde(skip)]
-    pub(crate) raw_json: Option<Vec<u8>>,
+    pub(crate) raw: Vec<u8>,
 }
 
 impl Response {
-    /// Returns the raw json string returned from the server.
-    /// If the server uses legacy protocol, (thus not returned json) it is simply `None`.
-    /// It is `Vec<u8>` because server is not guaranteed to return valid UTF-8.
-    pub fn raw_json(&self) -> Option<&[u8]> {
-        self.raw_json.as_deref()
+    /// The raw response returned from the server.
+    /// It is `Vec<u8>` because server is not guaranteed to return valid UTF-8,
+    /// even not a json at all.
+    pub fn raw(&self) -> &[u8] {
+        &self.raw
     }
 }
 
@@ -84,7 +84,7 @@ impl TryFrom<RawLatest> for Response {
             favicon,
             mod_info: raw.mod_info,
             forge_data: raw.forge_data,
-            raw_json: Some(raw.raw_json),
+            raw: raw.raw_json,
         })
     }
 }

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -73,7 +73,7 @@ where
     stream.read_to_end(&mut buffer).await?;
 
     let response = decode_legacy(&buffer)?;
-    parse_legacy(&response)
+    parse_legacy(&response, buffer)
 }
 
 async fn read_varint<Stream>(stream: &mut Stream) -> Result<i32>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ fn decode_legacy(buffer: &[u8]) -> Result<String> {
     String::from_utf16(&utf16be).map_err(|_| Error::UnsupportedProtocol)
 }
 
-fn parse_legacy(s: &str) -> Result<Response> {
+fn parse_legacy(s: &str, raw: Vec<u8>) -> Result<Response> {
     let mut fields = s.split('\0');
     let magic = fields.next().map(|s| s == "\u{00a7}\u{0031}");
     let protocol = fields.next().and_then(|s| s.parse().ok());
@@ -154,7 +154,7 @@ fn parse_legacy(s: &str) -> Result<Response> {
             forge_data: None,
             mod_info: None,
             sample: None,
-            raw_json: None,
+            raw,
         }),
         _ => Err(Error::UnsupportedProtocol),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![allow(clippy::clippy::needless_doctest_main)]
+#![allow(clippy::needless_doctest_main)]
 //! craftping provides a `ping` function to send Server List Ping requests to a Minecraft server.
 //!
 //! # Feature flags
@@ -97,7 +97,7 @@ fn build_latest_request(hostname: &str, port: u16) -> Result<Vec<u8>> {
 }
 
 fn decode_latest_response(buffer: &[u8]) -> Result<RawLatest> {
-    serde_json::from_slice(&buffer).map_err(|_| Error::UnsupportedProtocol)
+    serde_json::from_slice(buffer).map_err(|_| Error::UnsupportedProtocol)
 }
 
 const LEGACY_REQUEST: [u8; 35] = [

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -66,7 +66,7 @@ where
     stream.read_to_end(&mut buffer)?;
 
     let response = decode_legacy(&buffer)?;
-    parse_legacy(&response)
+    parse_legacy(&response, buffer)
 }
 
 fn read_varint(stream: &mut impl Read) -> Result<i32> {

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -73,7 +73,7 @@ where
     stream.read_to_end(&mut buffer).await?;
 
     let response = decode_legacy(&buffer)?;
-    parse_legacy(&response)
+    parse_legacy(&response, buffer)
 }
 
 async fn read_varint<Stream>(stream: &mut Stream) -> Result<i32>


### PR DESCRIPTION
- Fix `UnsupportedProtocol` error on FML servers
- Generalize `raw_json` field to `raw` so that all valid server response can be returned